### PR TITLE
feat: Add CRUD functionality for petugas

### DIFF
--- a/app/Http/Controllers/PetugasController.php
+++ b/app/Http/Controllers/PetugasController.php
@@ -2,9 +2,93 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Petugas;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
 
 class PetugasController extends Controller
 {
-    //
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $petugas = Petugas::all();
+        return view('petugas.index', compact('petugas'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function tambahPetugas()
+    {
+        return view('petugas.tambah');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'username' => 'required|string|max:25|unique:petugas',
+            'password' => 'required|string|min:6',
+            'nama_petugas' => 'required|string|max:50',
+            'level' => 'required|in:admin,petugas',
+        ]);
+
+        Petugas::create([
+            'username' => $request->username,
+            'password' => Hash::make($request->password),
+            'nama_petugas' => $request->nama_petugas,
+            'level' => $request->level,
+        ]);
+
+        return redirect()->route('petugas.index')->with('success', 'Petugas berhasil ditambahkan.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function editPetugas(Petugas $petugas)
+    {
+        return view('petugas.edit', compact('petugas'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Petugas $petugas)
+    {
+        $request->validate([
+            'username' => ['required', 'string', 'max:25', Rule::unique('petugas')->ignore($petugas->id)],
+            'nama_petugas' => 'required|string|max:50',
+            'level' => 'required|in:admin,petugas',
+        ]);
+
+        $data = [
+            'username' => $request->username,
+            'nama_petugas' => $request->nama_petugas,
+            'level' => $request->level,
+        ];
+
+        if ($request->filled('password')) {
+            $request->validate(['password' => 'string|min:6']);
+            $data['password'] = Hash::make($request->password);
+        }
+
+        $petugas->update($data);
+
+        return redirect()->route('petugas.index')->with('success', 'Petugas berhasil diperbarui.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Petugas $petugas)
+    {
+        $petugas->delete();
+        return redirect()->route('petugas.index')->with('success', 'Petugas berhasil dihapus.');
+    }
 }

--- a/app/Models/Petugas.php
+++ b/app/Models/Petugas.php
@@ -2,9 +2,51 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 
-class Petugas extends Model
+class Petugas extends Authenticatable
 {
-    //
+    use HasFactory, Notifiable;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'petugas';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'username',
+        'password',
+        'nama_petugas',
+        'level',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'password' => 'hashed',
+        ];
+    }
 }

--- a/resources/views/admin/components/navbar.blade.php
+++ b/resources/views/admin/components/navbar.blade.php
@@ -18,7 +18,7 @@
                 <i class="fas fa-users me-2"></i>
                 Kelas
             </a>
-            <a href="#" class="sidebar-link">
+            <a href="{{ route('petugas.index') }}" class="sidebar-link {{ request()->routeIs('petugas.*') ? 'active' : '' }}">
                 <i class="fas fa-user-tie me-2"></i>
                 Petugas
             </a>

--- a/resources/views/petugas/edit.blade.php
+++ b/resources/views/petugas/edit.blade.php
@@ -1,0 +1,50 @@
+<x-app-layout>
+    <div class="container-fluid p-4">
+        <div class="page">
+            @if ($errors->any())
+                <div class="alert alert-danger">
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+            <h1 class="h3 mb-4">Edit Data Petugas</h1>
+
+            <div class="card shadow">
+                <div class="card-body">
+                    <form action="{{ route('petugas.update', $petugas->id) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label for="username" class="form-label">Username</label>
+                            <input type="text" class="form-control" id="username" name="username" value="{{ old('username', $petugas->username) }}" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="password" class="form-label">Password (Opsional)</label>
+                            <input type="password" class="form-control" id="password" name="password">
+                            <small class="form-text text-muted">Kosongkan jika tidak ingin mengubah password.</small>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="nama_petugas" class="form-label">Nama Petugas</label>
+                            <input type="text" class="form-control" id="nama_petugas" name="nama_petugas" value="{{ old('nama_petugas', $petugas->nama_petugas) }}" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="level" class="form-label">Level</label>
+                            <select class="form-select" id="level" name="level" required>
+                                <option value="admin" {{ old('level', $petugas->level) == 'admin' ? 'selected' : '' }}>Admin</option>
+                                <option value="petugas" {{ old('level', $petugas->level) == 'petugas' ? 'selected' : '' }}>Petugas</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Simpan</button>
+                        <a href="{{ route('petugas.index') }}" class="btn btn-secondary">Batal</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/petugas/index.blade.php
+++ b/resources/views/petugas/index.blade.php
@@ -1,0 +1,57 @@
+<x-app-layout>
+    <div class="container-fluid p-4">
+        <div class="page">
+            <div class="card shadow">
+                @if (session('success'))
+                    <div class="alert alert-success alert-dismissible fade show" role="alert">
+                        {{ session('success') }}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                @endif
+                <div class="card-header py-3 d-flex justify-content-between align-items-center">
+                    <h6 class="m-0 font-weight-bold text-primary">Daftar Petugas</h6>
+                    <a href="{{ route('petugas.tambah') }}" class="btn btn-primary btn-sm">
+                        <i class="fas fa-plus me-2"></i>Tambah Petugas
+                    </a>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th style="text-align: center;">#</th>
+                                    <th style="text-align: center;">Username</th>
+                                    <th style="text-align: center;">Nama Petugas</th>
+                                    <th style="text-align: center;">Level</th>
+                                    <th style="text-align: center;">Aksi</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($petugas as $p)
+                                    <tr>
+                                        <td style="text-align: center; width: 80px;">{{ $loop->iteration }}</td>
+                                        <td>{{ $p->username }}</td>
+                                        <td>{{ $p->nama_petugas }}</td>
+                                        <td style="text-align: center;">{{ $p->level }}</td>
+                                        <td style="text-align: center; width: 120px;">
+                                            <a href="{{ route('petugas.edit', $p->id) }}" class="btn btn-info btn-sm me-1" title="Edit">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('petugas.destroy', $p->id) }}" method="post" style="display: inline;">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger btn-sm" title="Hapus" onclick="return confirm('Apakah Anda yakin ingin menghapus data ini?')">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/petugas/tambah.blade.php
+++ b/resources/views/petugas/tambah.blade.php
@@ -1,0 +1,49 @@
+<x-app-layout>
+    <div class="container-fluid p-4">
+        <div class="page">
+            @if ($errors->any())
+                <div class="alert alert-danger">
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+            <h1 class="h3 mb-4">Tambah Data Petugas</h1>
+
+            <div class="card shadow">
+                <div class="card-body">
+                    <form action="{{ route('petugas.store') }}" method="POST">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="username" class="form-label">Username</label>
+                            <input type="text" class="form-control" id="username" name="username" value="{{ old('username') }}" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="password" class="form-label">Password</label>
+                            <input type="password" class="form-control" id="password" name="password" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="nama_petugas" class="form-label">Nama Petugas</label>
+                            <input type="text" class="form-control" id="nama_petugas" name="nama_petugas" value="{{ old('nama_petugas') }}" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="level" class="form-label">Level</label>
+                            <select class="form-select" id="level" name="level" required>
+                                <option value="" disabled selected>Pilih Level</option>
+                                <option value="admin" {{ old('level') == 'admin' ? 'selected' : '' }}>Admin</option>
+                                <option value="petugas" {{ old('level') == 'petugas' ? 'selected' : '' }}>Petugas</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Simpan</button>
+                        <a href="{{ route('petugas.index') }}" class="btn btn-secondary">Batal</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\KelasController;
 use App\Http\Controllers\PembayaranController;
+use App\Http\Controllers\PetugasController;
 use App\Http\Controllers\SiswaController;
 use App\Http\Controllers\SppController;
 use Illuminate\Support\Facades\Route;
@@ -32,4 +33,12 @@ Route::middleware('auth')->group(function () {
     Route::get('/spp', [SppController::class, 'index'])->name('spp.index');
     Route::get('/pembayaran', [PembayaranController::class, 'index'])->name('pembayaran.index');
     Route::get('/pembayaran/tambah', [PembayaranController::class, 'tambahPembayaran'])->name('pembayaran.tambah');
+
+    // Petugas routes
+    Route::get('/petugas', [PetugasController::class, 'index'])->name('petugas.index');
+    Route::get('/petugas/tambah', [PetugasController::class, 'tambahPetugas'])->name('petugas.tambah');
+    Route::post('/petugas/tambah', [PetugasController::class, 'store'])->name('petugas.store');
+    Route::get('/petugas/edit/{petugas}', [PetugasController::class, 'editPetugas'])->name('petugas.edit');
+    Route::put('/petugas/edit/{petugas}', [PetugasController::class, 'update'])->name('petugas.update');
+    Route::delete('/petugas/hapus/{petugas}', [PetugasController::class, 'destroy'])->name('petugas.destroy');
 });


### PR DESCRIPTION
Adds a full CRUD (Create, Read, Update, Delete) interface for managing "petugas" (officers/staff).

This change includes:
- A `PetugasController` with methods to handle all CRUD operations.
- An updated `Petugas` Eloquent model, configured for authentication.
- Routes for all "petugas" actions, protected by the `auth` middleware.
- Blade views for listing, creating, and editing "petugas" records.
- An update to the main navigation bar to include a link to the "petugas" management page.

The implementation follows existing patterns in the codebase for consistency.